### PR TITLE
Extended the change hostname part by adding 3 new default variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,4 +18,18 @@ sap_preconfigure_modify_etc_hosts: no
 #  "Configuring Process Resource Limits" of SAP note 2002167/2772999):
 # sap_preconfigure_db_group_name: dba
 
+# Default Values for setting SAP Hostname according SAP Note#2002167
+#
+# Normally ansible_hostname, etc. is used on the admin network, while the service hostname that
+# need to be checked is a different one.
+# In this case, or if DNS is not configured properly, you need to set the following variables explizitly
+
+# SAP Hostname
+sap_preconfigure_hostname: '{{ ansible_hostname }}'
+# SAP Domain
+sap_preconfigure_domain: '{{ ansible_domain }}'
+# SAP IP Address
+sap_preconfigure_ip: '{{ ansible_default_ipv4.address }}'
+
+
 ...

--- a/tasks/sapnote/2002167/02-configuration-changes.yml
+++ b/tasks/sapnote/2002167/02-configuration-changes.yml
@@ -22,6 +22,7 @@
   command: getenforce
   register: getenforce_result
   changed_when: false
+  when: not ansible_check_mode
 - debug:
     var: getenforce_result.stdout_lines
 

--- a/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -5,54 +5,99 @@
 - debug:
     msg: "SAP note 2002167 Step 3: Setting the Hostname"
 
-- name: Make sure the short hostname is returned with "hostname" command and not FQDN
-  shell: |
-     if [ $(hostname -s) == $(hostname) -a $(hostname -f) == $(hostname).$(hostname -d) ]; then
-        rc=0
-     else
-        hostnamectl set-hostname $(hostname -s)
-        rc=1
-     fi
-     exit $rc
-  register: change_hostname
-  changed_when: change_hostname.rc == 1
-  failed_when: change_hostname.rc >= 2
+### The hostname module sets the hostname using hostnamectl on the system
 
-- name: Check if ipv4 address, FQDN, and hostname are in /etc/hosts
-  command: bash -lc "awk 'BEGIN{a=0}/{{ ansible_default_ipv4.address }}/&&/{{ ansible_hostname }}.{{ ansible_domain }}/&&/{{ ansible_hostname }}/{a++}END{print a}' /etc/hosts"
-  register: command_result
-  changed_when: no
-- debug:
-    var: command_result.stdout_lines, command_result.stderr_lines
-  when:
-    - not sap_preconfigure_modify_etc_hosts | bool
+- name: ensure short system hostname is set
+  hostname:
+    name: '{{ sap_preconfigure_hostname }}'
 
-- debug:
-    msg:
-      - "Expected:"
-      - "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}.{{ ansible_domain }} {{ ansible_hostname }}"
-  when:
-    - command_result.stdout != "1"
-    - not sap_preconfigure_modify_etc_hosts | bool
+### This little shell snippet saves all alias that might be already configured in the
+### hosts file to the variable sap_base_settings_register_hostname_aliases
 
-- fail:
-    msg:
-    - "Server's ipv4 address, FQDN, or hostname are not in /etc/hosts!"
-  when:
-    - command_result.stdout != "1"
-    - not sap_preconfigure_modify_etc_hosts | bool
+- name: modify /etc/hosts
+  block:
+    - name: get all hostaliases of {{ sap_preconfigure_ip }}
+      shell: |
+            awk ' ( $1 == "{{ sap_preconfigure_ip }}" ) {
+                    for (i=2; i<=NF; ++i) {
+                      if (( $i != "{{ sap_preconfigure_hostname }}" ) && ( $i != "{{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }}" )) { printf $i" " }
+                    }
+                   }' /etc/hosts
 
-- name: Make sure server's IP address is in /etc/hosts
-  lineinfile:
-    path: /etc/hosts
-    regexp: '^{{ ansible_default_ipv4.address }}'
-    insertbefore: '^127.0.0.1'
-#    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}.{{ ansible_domain }} {{ ansible_hostname }}"
-    state: present
+      register: sap_preconfigure_register_hostname_aliases
+      changed_when: false
+      check_mode: no
+
+      ## The next module set the hostentry as required including the previously collected aliasses
+  
+    - name: ensure hostentry is correct
+      lineinfile:
+            path: /etc/hosts
+            regexp: '^{{ sap_preconfigure_ip }}\s'
+            line: '{{ sap_preconfigure_ip }} {{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }} {{ sap_preconfigure_hostname }} {{ sap_preconfigure_register_hostname_aliases.stdout }}'
+
+      ### To make sure that my routine works and some maybe previous misconfigurations are not put in the hosts entry
+      ### I double check that there are no double entries of ip or hostnames in the etc host
+
+    # This task is skipped in check mode as nothing has changed
+    - name: check for double entries of {{ sap_preconfigure_ip }} in /etc/hosts
+      shell: |
+            n=$(grep "^{{ sap_preconfigure_ip }}\s" /etc/hosts | wc -l)
+            if [ $n -eq 1 ]; then
+               exit 0
+            else
+               echo "Duplicate IP Entry in /etc/hosts"
+               exit 1
+            fi
+      changed_when: false
+      when:  not ansible_check_mode
+
+    # This task is skipped in check mode as nothing has changed
+    - name: check for double entries of hostnames in /etc/hosts
+      shell: |
+            n=$(grep -w "{{ item }}" /etc/hosts | wc -l)
+            if [ $n -eq 1 ]; then
+               exit 0
+            else
+               exit 1
+            fi
+      changed_when: false
+      with_items:
+            - '{{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }}'
+            - '{{ sap_preconfigure_hostname }}'
+      when:  not ansible_check_mode
+
   when:
     - sap_preconfigure_modify_etc_hosts | bool
+
+- name: Verify that /etc/host entry is correct for DNS resolution
+  block:
+    - name: Check if ipv4 address, FQDN, and hostname are in /etc/hosts
+      command: bash -lc "awk 'BEGIN{a=0}/{{ sap_preconfigure_ip }}/&&/{{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }}/&&/{{ sap_preconfigure_hostname }}/{a++}END{print a}' /etc/hosts"
+      register: sap_preconfigure_register_command_result
+      changed_when: false
+      check_mode: no
+    - debug:
+        var: sap_preconfigure_register_command_result.stdout_lines, sap_preconfigure_register_command_result.stderr_lines
+    - debug:
+        msg:
+          - "Expected:"
+          - "{{ sap_preconfigure_ip }} {{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }} {{ sap_preconfigure_hostname }}"
+      when:
+        - sap_preconfigure_register_command_result.stdout != "1"
+    
+    # this Error is ignored in ansible check mode
+    - fail:
+        msg:
+        - "Server's ipv4 address, FQDN, or hostname are not in /etc/hosts!"
+      when:
+        - sap_preconfigure_register_command_result.stdout != "1"
+      ignore_errors: "{{ ansible_check_mode }}"
+
+  when:
+     - not sap_preconfigure_modify_etc_hosts | bool
+  
 - debug:
-    msg: "System {{ ansible_hostname }}, {{ ansible_hostname }}.{{ ansible_domain }} has ipv4 address {{ ansible_default_ipv4.address }}"
+      msg: "System {{ sap_preconfigure_hostname }}, {{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }} has ipv4 address {{ sap_preconfigure_ip }}"
 
 ...

--- a/tasks/sapnote/2772999/02-configure-selinux.yml
+++ b/tasks/sapnote/2772999/02-configure-selinux.yml
@@ -14,6 +14,8 @@
   command: getenforce
   register: getenforce_result
   changed_when: false
+  check_mode: no
+
 - debug:
     var: getenforce_result.stdout_lines
 

--- a/tasks/sapnote/2772999/03-configure-hostname.yml
+++ b/tasks/sapnote/2772999/03-configure-hostname.yml
@@ -5,54 +5,99 @@
 - debug:
     msg: "SAP note 2772999 Step 3: Configure Hostname"
 
-- name: Make sure the short hostname is returned with "hostname" command and not FQDN
-  shell: |
-     if [ $(hostname -s) == $(hostname) -a $(hostname -f) == $(hostname).$(hostname -d) ]; then
-        rc=0
-     else
-        hostnamectl set-hostname $(hostname -s)
-        rc=1
-     fi
-     exit $rc
-  register: change_hostname
-  changed_when: change_hostname.rc == 1
-  failed_when: change_hostname.rc >= 2
+### The hostname module sets the hostname using hostnamectl on the system
 
-- name: Check if ipv4 address, FQDN, and hostname are in /etc/hosts
-  command: bash -lc "awk 'BEGIN{a=0}/{{ ansible_default_ipv4.address }}/&&/{{ ansible_hostname }}.{{ ansible_domain }}/&&/{{ ansible_hostname }}/{a++}END{print a}' /etc/hosts"
-  register: command_result
-  changed_when: no
-- debug:
-    var: command_result.stdout_lines, command_result.stderr_lines
-  when:
-    - not sap_preconfigure_modify_etc_hosts | bool
+- name: ensure short system hostname is set
+  hostname:
+    name: '{{ sap_preconfigure_hostname }}'
 
-- debug:
-    msg:
-      - "Expected:"
-      - "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}.{{ ansible_domain }} {{ ansible_hostname }}"
-  when:
-    - command_result.stdout != "1"
-    - not sap_preconfigure_modify_etc_hosts | bool
+### This little shell snippet saves all alias that might be already configured in the
+### hosts file to the variable sap_base_settings_register_hostname_aliases
 
-- fail:
-    msg:
-    - "Server's ipv4 address, FQDN, or hostname are not in /etc/hosts!"
-  when:
-    - command_result.stdout != "1"
-    - not sap_preconfigure_modify_etc_hosts | bool
+- name: modify /etc/hosts
+  block:
+    - name: get all hostaliases of {{ sap_preconfigure_ip }}
+      shell: |
+            awk ' ( $1 == "{{ sap_preconfigure_ip }}" ) {
+                    for (i=2; i<=NF; ++i) {
+                      if (( $i != "{{ sap_preconfigure_hostname }}" ) && ( $i != "{{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }}" )) { printf $i" " }
+                    }
+                   }' /etc/hosts
 
-- name: Make sure server's IP address is in /etc/hosts
-  lineinfile:
-    path: /etc/hosts
-    regexp: '^{{ ansible_default_ipv4.address }}'
-    insertbefore: '^127.0.0.1'
-#    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}.{{ ansible_domain }} {{ ansible_hostname }}"
-    state: present
+      register: sap_preconfigure_register_hostname_aliases
+      changed_when: false
+      check_mode: no
+
+      ## The next module set the hostentry as required including the previously collected aliasses
+  
+    - name: ensure hostentry is correct
+      lineinfile:
+            path: /etc/hosts
+            regexp: '^{{ sap_preconfigure_ip }}\s'
+            line: '{{ sap_preconfigure_ip }} {{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }} {{ sap_preconfigure_hostname }} {{ sap_preconfigure_register_hostname_aliases.stdout }}'
+
+      ### To make sure that my routine works and some maybe previous misconfigurations are not put in the hosts entry
+      ### I double check that there are no double entries of ip or hostnames in the etc host
+
+    # This task is skipped in check mode as nothing has changed
+    - name: check for double entries of {{ sap_preconfigure_ip }} in /etc/hosts
+      shell: |
+            n=$(grep "^{{ sap_preconfigure_ip }}\s" /etc/hosts | wc -l)
+            if [ $n -eq 1 ]; then
+               exit 0
+            else
+               echo "Duplicate IP Entry in /etc/hosts"
+               exit 1
+            fi
+      changed_when: false
+      when:  not ansible_check_mode
+
+    # This task is skipped in check mode as nothing has changed
+    - name: check for double entries of hostnames in /etc/hosts
+      shell: |
+            n=$(grep -w "{{ item }}" /etc/hosts | wc -l)
+            if [ $n -eq 1 ]; then
+               exit 0
+            else
+               exit 1
+            fi
+      changed_when: false
+      with_items:
+            - '{{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }}'
+            - '{{ sap_preconfigure_hostname }}'
+      when:  not ansible_check_mode
+
   when:
     - sap_preconfigure_modify_etc_hosts | bool
+
+- name: Verify that /etc/host entry is correct for DNS resolution
+  block:
+    - name: Check if ipv4 address, FQDN, and hostname are in /etc/hosts
+      command: bash -lc "awk 'BEGIN{a=0}/{{ sap_preconfigure_ip }}/&&/{{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }}/&&/{{ sap_preconfigure_hostname }}/{a++}END{print a}' /etc/hosts"
+      register: sap_preconfigure_register_command_result
+      changed_when: false
+      check_mode: no
+    - debug:
+        var: sap_preconfigure_register_command_result.stdout_lines, sap_preconfigure_register_command_result.stderr_lines
+    - debug:
+        msg:
+          - "Expected:"
+          - "{{ sap_preconfigure_ip }} {{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }} {{ sap_preconfigure_hostname }}"
+      when:
+        - sap_preconfigure_register_command_result.stdout != "1"
+    
+    # this Error is ignored in ansible check mode
+    - fail:
+        msg:
+        - "Server's ipv4 address, FQDN, or hostname are not in /etc/hosts!"
+      when:
+        - sap_preconfigure_register_command_result.stdout != "1"
+      ignore_errors: "{{ ansible_check_mode }}"
+
+  when:
+     - not sap_preconfigure_modify_etc_hosts | bool
+  
 - debug:
-    msg: "System {{ ansible_hostname }}, {{ ansible_hostname }}.{{ ansible_domain }} has ipv4 address {{ ansible_default_ipv4.address }}"
+      msg: "System {{ sap_preconfigure_hostname }}, {{ sap_preconfigure_hostname }}.{{ sap_preconfigure_domain }} has ipv4 address {{ sap_preconfigure_ip }}"
 
 ...

--- a/tasks/sapnote/2772999/07-configure-tmpfs.yml
+++ b/tasks/sapnote/2772999/07-configure-tmpfs.yml
@@ -16,19 +16,24 @@
   command: bash -lc "grep /dev/shm /etc/fstab"
   register: shell_result
   changed_when: False
+  when: not ansible_check_mode
 - debug:
     var: shell_result.stdout_lines, shell_result.stderr_lines
 
+# This task may throw an error if tmpfs is not configured, so it is skipped in check_mode
 - name: Remount /dev/shm
   command: bash -lc "mount -o remount /dev/shm"
   register: shell_result
+  when: not ansible_check_mode
 - debug:
     var: shell_result.stdout_lines, shell_result.stderr_lines
+  when: not ansible_check_mode
 
 - name: Check if /dev/shm is available
   command: bash -lc "df -k /dev/shm"
   register: shell_result
   changed_when: False
+  when: not ansible_check_mode
 - debug:
     var: shell_result.stdout_lines, shell_result.stderr_lines
 


### PR DESCRIPTION
This pull request has conflicts, because both of us have worked on the configure hostname module.
This has to be sorted out ....

In addition conditions are added, so that the roles runs well with "--check" and just reports changes, it would do.

Default Values for setting SAP Hostname according SAP Note#2002167

Normally ansible_hostname, etc. is used on the admin network, while the service hostname that
need to be checked is a different one.
In this case, or if DNS is not configured properly, you need to set the following variables explizitly
By introducing the variables, they can be overwritten, but the default is not changed

sap_preconfigure_hostname: '{{ ansible_hostname }}'
sap_preconfigure_domain: '{{ ansible_domain }}'
sap_preconfigure_ip: '{{ ansible_default_ipv4.address }}'

